### PR TITLE
catch weird (empty) transactions

### DIFF
--- a/src/model/TransactionsExplorer.ts
+++ b/src/model/TransactionsExplorer.ts
@@ -113,6 +113,13 @@ export class TransactionsExplorer {
 			return false;
 		}
 		return parseInt(rawTransaction.vout[0].amount) !== 0;
+                try {
+                    return parseInt(rawTransaction.vout[0].amount) !== 0;
+                }
+                catch(err) {
+                    console.error('Weird tx !', rawTransaction);
+                    return false;
+                }
 	}
 
 	static parse(rawTransaction: RawDaemon_Transaction, wallet: Wallet): Transaction | null {


### PR DESCRIPTION
Otherwise the wallet encounters an error and stops scanning