### PR TITLE
Update to wallet.getmasari.org

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -5,9 +5,9 @@ global.config = {
 		'https://wallet.getmasari.org:38084/'
 	],
 	phpRelay:typeof window !== 'undefined' ? true : false,
-	mainnetExplorerUrl: "https://msrchain.net/",
-	mainnetExplorerUrlHash: "https://msrchain.net/tx/{ID}",
-	mainnetExplorerUrlBlock: "https://msrchain.net/block/{ID}",
+	mainnetExplorerUrl: "https://explorer.getmasari.org/",
+	mainnetExplorerUrlHash: "https://explorer.getmasari.org/transaction.html?hash={ID}",
+	mainnetExplorerUrlBlock: "https://explorer.getmasari.org/block.html?height={ID}",
 	testnetExplorerUrl: "http://testnet.msrchain.net/",
 	testnetExplorerUrlHash: "http://testnet.msrchain.net/tx/{ID}",
 	testnetExplorerUrlBlock: "http://testnet.msrchain.net/block/{ID}",

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,8 +1,8 @@
 let global : any = typeof window !== 'undefined' ? window : self;
 global.config = {
-	apiUrl:typeof window !== 'undefined' && window.location ? window.location.href.substr(0,window.location.href.lastIndexOf('/')+1)+'api/' : 'https://www.masariwallet.com/api/',
+	apiUrl:typeof window !== 'undefined' && window.location ? window.location.href.substr(0,window.location.href.lastIndexOf('/')+1)+'api/' : 'https://wallet.getmasari.org/api/',
 	trustedDaemonsAddresses:[
-		'https://www.masariwallet.com:38084/'
+		'https://wallet.getmasari.org:38084/'
 	],
 	phpRelay:typeof window !== 'undefined' ? true : false,
 	mainnetExplorerUrl: "https://msrchain.net/",

--- a/src/index.html
+++ b/src/index.html
@@ -37,11 +37,11 @@
 	<meta property="twitter:description" content="" />
 
 	<meta property="og:type" content="website" />
-	<meta property="og:url" content="https://www.masariwallet.com/" />
-	<meta property="og:image" content="https://www.masariwallet.com/images/icons/icon-144x144.png" />
+	<meta property="og:url" content="https://wallet.getmasari.org/" />
+	<meta property="og:image" content="https://wallet.getmasari.org/images/icons/icon-144x144.png" />
 
 	<meta property="twitter:card" content="summary" />
-	<meta property="twitter:site" content="https://www.masariwallet.com/" />
+	<meta property="twitter:site" content="https://wallet.getmasari.org/" />
 
 	<meta property="twitter:creator" content="@masaricurrency" />
 
@@ -75,7 +75,7 @@
 <div id="page" ></div>
 
 <div id="copyright" v-cloak="" >
-	<div class="hideOnNative" >© 2018 www.masariwallet.com</div>
+	<div class="hideOnNative" >© 2018-2019 The Masari Project</div>
 	<div class="links" >
 		<select v-model="language" class="hideOnNative">
 			<option value="en">English</option>
@@ -94,7 +94,7 @@
 		<a class="hideOnNative" href="#!donate" >{{ $t("bottom.donate") }}</a>
 		<a class="hideOnNative" href="#!network" >{{ $t("bottom.network") }}</a>
 		<a class="hideOnNative" href="https://get.masaricoin.com" target="_blank" >{{ $t("bottom.miningPool") }}</a>
-		<a class="hideOnNative" href="https://github.com/gnock/masari-webwallet" target="_blank">{{ $t("bottom.github") }}</a>
+		<a class="hideOnNative" href="https://github.com/masari-project/masari-webwallet" target="_blank">{{ $t("bottom.github") }}</a>
 	</div>
 	<div class="cb" ></div>
 </div>

--- a/src/pages/privacyPolicy.html
+++ b/src/pages/privacyPolicy.html
@@ -68,7 +68,7 @@
 
 					<h3>7. More Info</h3>
 					<p>
-						This wallet is based on the client side masariwallet.com. Terms of use and further information can be found there. The mobile wallet Publisher is producing
+						This wallet is based on the client side. Terms of use and further information can be found there. The mobile wallet Publisher is producing
 						this application to the benefit of the Masari community. It is completely open source and can be replicated by any project. Licensing and developer
 						documentation is available on GitHub at <a href="https://github.com/masari-project/masari-webwallet" >https://github.com/masari-project/masari-webwallet</a>.
 					</p>

--- a/src/pages/termsOfUse.html
+++ b/src/pages/termsOfUse.html
@@ -12,12 +12,12 @@
 			<div class="body" >
 				<div class="content" >
 					English version: <br/>
-					It is understood that interactions with masariwallet.com’s web wallet are entirely client-side. <br/>
-					That masariwallet.com has no control or access to your wallet’s private keys, nor do they have the ability to recover your funds in any event of loss.<br/>
-					In all circumstances, masariwallet.com, Masari Core Team, Masari promoters, or any entity affiliated with the Masari project will not be liable for loss or misuse of funds held using the aforementioned wallet.<br/>
-					Users also understand and agree that they are solely responsible for providing a secure environment to interact with a masariwallet.com web wallet.<br/>
-					Additionally, masariwallet.com cannot, and will not, be held liable for use of funds originating from or arriving to a web wallet.<br/>
-					By creating, importing, or interacting with a wallet on masariwallet.com, you implicitly agree to these terms, and absolve the website owners and affiliates of any and all liability.<br/>
+					It is understood that interactions with The Masari Project's web wallet are entirely client-side. <br/>
+					The Masari Project has no control or access to your wallet's private keys, nor do they have the ability to recover your funds in any event of loss.<br/>
+					In all circumstances, The Masari Project, Masari promoters, or any entity affiliated with the Masari Project will not be liable for loss or misuse of funds held using the aforementioned wallet.<br/>
+					Users also understand and agree that they are solely responsible for providing a secure environment to interact with the Masari Project's web wallet.<br/>
+					Additionally, The Masari Project cannot, and will not, be held liable for use of funds originating from or arriving to a web wallet.<br/>
+					By creating, importing, or interacting with a wallet on this website, you implicitly agree to these terms, and absolve the website owners and affiliates of any and all liability.<br/>
 					<br/>
 					<a href="#!privacyPolicy" >Privacy policy (EN)</a>
 				</div>


### PR DESCRIPTION
This rewords a few things as seen on wallet.getmasari.org.

Changes config to use wallet.getmasari.org as URL/trusted daemon. 
Also uses the explorer by @gnock as seen at explorer.getmasari.org

If/when SSL issue is fixed on masariwallet.com (the SSL for daemon proxy is expired), we can restore the url for it under trusted daemons.